### PR TITLE
Fixed time reset when dialog is open

### DIFF
--- a/dist/bootstrap-session-timeout.js
+++ b/dist/bootstrap-session-timeout.js
@@ -94,7 +94,10 @@
         // Reset timer on any of these events
         if (!opt.ignoreUserActivity) {
             $(document).on('keyup mouseup mousemove touchend touchmove', function() {
-                startSessionTimer();
+                if(!$('#session-timeout-dialog').hasClass('in')) {
+					// If warning dialog is not already open start session timer
+					startSessionTimer();
+				}
             });
         }
 
@@ -149,9 +152,8 @@
         function startDialogTimer() {
             // Clear session timer
             clearTimeout(timer);
-            if (!$('#session-timeout-dialog').hasClass('in') && (opt.countdownMessage || opt.countdownBar)) {
-                // If warning dialog is not already open and either opt.countdownMessage
-                // or opt.countdownBar are set start countdown
+            if ((opt.countdownMessage || opt.countdownBar)) {
+                // If either opt.countdownMessage or opt.countdownBar are set start countdown
                 startCountdownTimer('dialog', true);
             }
             // Set dialog timer

--- a/dist/bootstrap-session-timeout.js
+++ b/dist/bootstrap-session-timeout.js
@@ -95,9 +95,9 @@
         if (!opt.ignoreUserActivity) {
             $(document).on('keyup mouseup mousemove touchend touchmove', function() {
                 if(!$('#session-timeout-dialog').hasClass('in')) {
-					// If warning dialog is not already open start session timer
-					startSessionTimer();
-				}
+			// If warning dialog is not already open start session timer
+			startSessionTimer();
+		}
             });
         }
 


### PR DESCRIPTION
When the countdown timer was enabled and the user performed activities while the dialog was open, the countdown timer would reset. This moves the code that checks whether the dialog is open into the event listening function so startSessionTimer() doesn't run (and therefore reset the countdown timer) if the dialog is open. It was not working for me in its previous location.
