### PR TITLE
Fix data(...).isShown is null or not an object error in IE8

### DIFF
--- a/dist/bootstrap-session-timeout.js
+++ b/dist/bootstrap-session-timeout.js
@@ -100,6 +100,7 @@
                 // If they moved the mouse not only reset the counter
                 // but remove the modal too!
                 if( $('#session-timeout-dialog').length > 0 && 
+                    typeof $('#session-timeout-dialog').data('bs.modal') != 'undefined' && // IE8 fix
                     $('#session-timeout-dialog').data('bs.modal').isShown )
                 {
                    // http://stackoverflow.com/questions/11519660/twitter-bootstrap-modal-backdrop-doesnt-disappear


### PR DESCRIPTION
In IE8 the error "Fix data(...).isShown is null or not an object" stops the plugin working. With this patch everything appears to work fine.
