### PR TITLE
ability to hide action buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,15 +12,12 @@ Idle time is defined as no mouse, keyboard or touch event activity registered by
 
 As long as the user is active, the (optional) keep-alive URL keeps getting pinged and the session stays alive. If you have no need to keep the server-side session alive via the keep-alive URL, you can also use this plugin as a simple lock mechanism that redirects to your lock-session or log-out URL after a set amount of idle time.
 
-
 ## Getting Started
 
 1. Download or git clone.
 2. Run `bower install` to install dependencies or if you prefer to do it manually: include jQuery, Bootstrap JS and CSS (required if you want to use Bootstrap modal window).
 3. Include `bootstrap-session-timeout.js` or the minified version `bootstrap-session-timeout.min.js`
 4. Call `$.sessionTimeout();` on document ready. See available options below or take a look at the examples.
-
-
 
 ## Documentation
 ### Options
@@ -169,7 +166,6 @@ Default: `false`
 
 Optional callback fired when first calling the plugin and every time user refreshes the session (on any mouse, keyboard or touch action). Takes options object as the only argument.
 
-
 **onWarn**
 
 Type: `Function` or `Boolean`
@@ -188,10 +184,17 @@ Default: `false`
 
 Custom callback you can use instead of redirecting the user to `redirUrl`. Takes options object as the only argument.
 
+**hideButtons**
+
+Type: `Boolean`
+
+Default: `false`
+
+Disable action buttons
+
 ## Examples
 
 You can play around with the examples in the `/examples` directory.
-
 
 **Basic Usage**
 
@@ -264,7 +267,7 @@ In lieu of a formal styleguide, take care to maintain the existing coding style.
 	 * Fixes various reported bugs
  * **1.0.2** `2015-02-10`
 	 * Added optional onStart callback.
-	 * All custom callbacks nowreceive options object as argument. 
+	 * All custom callbacks nowreceive options object as argument.
 	 * Added optional countdown message. Added optional countdown bar.
  * **1.0.1** `2014-01-23`
 	 * Added an option to send data to the keep-alive URL.

--- a/dist/bootstrap-session-timeout.js
+++ b/dist/bootstrap-session-timeout.js
@@ -30,7 +30,8 @@
             onRedir: false,
             countdownMessage: false,
             countdownBar: false,
-            countdownSmart: false
+            countdownSmart: false,
+            hideButtons: false
         };
 
         var opt = defaults,
@@ -61,25 +62,31 @@
                 </div>' : '';
 
             // Create timeout warning dialog
-            $('body').append('<div class="modal fade" id="session-timeout-dialog"> \
-              <div class="modal-dialog"> \
-                <div class="modal-content"> \
-                  <div class="modal-header"> \
-                    <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button> \
-                    <h4 class="modal-title">' + opt.title + '</h4> \
-                  </div> \
-                  <div class="modal-body"> \
-                    <p>' + opt.message + '</p> \
-                    ' + countdownMessage + ' \
-                    ' + coundownBarHtml + ' \
-                  </div> \
-                  <div class="modal-footer"> \
-                    <button id="session-timeout-dialog-logout" type="button" class="btn btn-default">' + opt.logoutButton + '</button> \
-                    <button id="session-timeout-dialog-keepalive" type="button" class="btn btn-primary" data-dismiss="modal">' + opt.keepAliveButton + '</button> \
+            var warningText =
+              '<div class="modal fade" id="session-timeout-dialog"> \
+                <div class="modal-dialog"> \
+                  <div class="modal-content"> \
+                    <div class="modal-header"> \
+                      <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button> \
+                      <h4 class="modal-title">' + opt.title + '</h4> \
+                    </div> \
+                    <div class="modal-body"> \
+                      <p>' + opt.message + '</p> \
+                      ' + countdownMessage + ' \
+                      ' + coundownBarHtml + ' \
+                    </div>';
+            if(!opt.hideButtons){
+              warningText += ' \
+                    <div class="modal-footer"> \
+                      <button id="session-timeout-dialog-logout" type="button" class="btn btn-default">' + opt.logoutButton + '</button> \
+                      <button id="session-timeout-dialog-keepalive" type="button" class="btn btn-primary" data-dismiss="modal">' + opt.keepAliveButton + '</button> \
+                    </div>';
+            }
+            warningText += ' \
                   </div> \
                 </div> \
-              </div> \
-             </div>');
+              </div>';
+            $('body').append(warningText);
 
             // "Logout" button click
             $('#session-timeout-dialog-logout').on('click', function() {


### PR DESCRIPTION
If `ignoreUserActivity` is set to `false`, moving the mouse removes the dialog, so having the buttons is confusing. One option is to have an option to not display the buttons. 
